### PR TITLE
Prepend deploy status route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,0 @@
-Rails.application.routes.draw do
-  get "deploy_status", to: "varvet/deploy_status#index"
-end

--- a/lib/varvet.rb
+++ b/lib/varvet.rb
@@ -15,6 +15,12 @@ module Varvet
           ::Rails.logger.level = Logger.const_get("INFO")
         end
       end
+
+      config.after_initialize do
+        ::Rails.application.routes.draw do
+          get "deploy_status", to: "varvet/deploy_status#index"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Apparently routes.prepend doesn't work from engines: https://github.com/wireframe/email_preview/pull/17

@mwq @Linuus 