### PR TITLE
Adds test and development gems to varvet gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.tags

--- a/lib/varvet.rb
+++ b/lib/varvet.rb
@@ -10,6 +10,21 @@ module Varvet
     end
 
     class Railtie < ::Rails::Railtie
+      config.before_configuration do
+        if ::Rails.env.test?
+          require "m"
+          require "minitest/reporters"
+          require "minitest"
+          require "codeclimate-test-reporter"
+        end
+
+        if ::Rails.env.development?
+          require "better_errors"
+          require "binding_of_caller"
+          require "meta_request"
+        end
+      end
+
       config.before_initialize do
         if ::Rails.env.production?
           ::Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))

--- a/lib/varvet/version.rb
+++ b/lib/varvet/version.rb
@@ -1,3 +1,3 @@
 module Varvet
-  VERSION = "1.4.9"
+  VERSION = "1.5.0"
 end

--- a/varvet.gemspec
+++ b/varvet.gemspec
@@ -19,15 +19,27 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  # Production
   gem.add_dependency "appsignal", "~> 0.11.2"
   gem.add_dependency "foreman", "~> 0.76.0"
+  gem.add_dependency "lograge", "~> 0.3.1"
   gem.add_dependency "pry-byebug", "~> 3.0.1"
   gem.add_dependency "pry-doc", "~> 0.6.0"
   gem.add_dependency "pry-rails", "~> 0.3.2"
   gem.add_dependency "rails", "~> 4.1"
   gem.add_dependency "thor", "~> 0.19.1"
   gem.add_dependency "unicorn", "~> 4.8.3"
-  gem.add_dependency "lograge", "~> 0.3.1"
+
+  # Test
+  gem.add_dependency "codeclimate-test-reporter", "~> 0.4.7"
+  gem.add_dependency "m", "~> 1.3.4"
+  gem.add_dependency "minitest-reporters", "~> 1.0.17"
+  gem.add_dependency "minitest", "~> 5.7.0"
+
+  # Development
+  gem.add_dependency "better_errors", "~> 1.1.0"
+  gem.add_dependency "binding_of_caller", "~> 0.7.2"
+  gem.add_dependency "meta_request", "~> 0.3.4"
 
   gem.add_development_dependency "bundler", "~> 1.7"
   gem.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The following gems are now bundled and can be removed from a project's Gemfile:

- codeclimate-test-reporter
- m
- minitest
- minitest-reporters
- better_errors
- binding_of_caller
- meta_request
